### PR TITLE
Serial number

### DIFF
--- a/optoforce/launch/optoforce.launch
+++ b/optoforce/launch/optoforce.launch
@@ -31,6 +31,9 @@
   <!-- Numerical index of the first sensor. The rest (if this is a multi-channel DAC)
   will get the consecutive numbers -->
   <arg name="starting_index" default="0"/>
+  <!-- When append_serial_number is set to true, the topic on which wrenches are
+  published will be named after the sensor's serial number. -->
+  <arg name="append_serial_number" default="true"/>
   <!-- Direction of scaling file -->
   <arg name="scaling_file" default="$(find optoforce)/config/multi_channel_3_axis_generic_scale.yaml"/>
 
@@ -41,6 +44,7 @@
     <param name="zero" value="$(arg zero)"/>
     <param name="type" value="$(arg type)"/>
     <param name="starting_index" value="$(arg starting_index)"/>
+    <param name="append_serial_number" value="$(arg append_serial_number)"/>
     <rosparam command="load" file="$(arg scaling_file)"/>
   </node>
 </launch>

--- a/optoforce/src/optoforce/optoforce.py
+++ b/optoforce/src/optoforce/optoforce.py
@@ -92,7 +92,7 @@ class OptoforceDriver(object):
         sensor_type_param = rospy.get_param("~type", "m-ch/3-axis")
         self._sensor_type = self._daq_type_map[sensor_type_param]
         self._starting_index = rospy.get_param("~starting_index", 0)
-        self._append_topic_serial = rospy.get_param("~append_serial_number", False)
+        self._append_topic_serial = rospy.get_param("~append_serial_number", "false")
         self._publishers = []
         self._wrenches = []
         self._nb_sensors = 0

--- a/optoforce/src/optoforce/optoforce.py
+++ b/optoforce/src/optoforce/optoforce.py
@@ -21,6 +21,7 @@ import serial
 import struct
 import binascii
 import rospy
+import std_srvs.srv
 from geometry_msgs.msg import WrenchStamped
 
 
@@ -84,7 +85,7 @@ class OptoforceDriver(object):
         self._wrenches = []
         self._nb_sensors = 0
         self._nb_axis = 0
-        
+
         if self._sensor_type == self._OPTOFORCE_TYPE_31:
             self._nb_sensors = 1
             self._nb_axis = 3
@@ -94,15 +95,15 @@ class OptoforceDriver(object):
         elif self._sensor_type == self._OPTOFORCE_TYPE_64:
             self._nb_sensors = 1
             self._nb_axis = 6
-            
+
         self._scale = rospy.get_param("~scale")
 
         if len(self._scale) != self._nb_sensors:
-            raise ValueError("Number of sensors [%i]and scaling factor vectors [%i] given doesn't match." % (self._nb_sensors, len(self._scale))) 
+            raise ValueError("Number of sensors [%i]and scaling factor vectors [%i] given doesn't match." % (self._nb_sensors, len(self._scale)))
         else:
             for x in range(self._nb_sensors):
                 if len(self._scale[x]) != self._nb_axis:
-                    raise ValueError("Number of axis [%i] and scaling factors [%i] given doesn't match." % (self._nb_axis, len(self._scale[x]))) 
+                    raise ValueError("Number of axis [%i] and scaling factors [%i] given doesn't match." % (self._nb_axis, len(self._scale[x])))
 
         for i in range(self._nb_sensors):
             self._publishers.append(rospy.Publisher("optoforce_" + str(self._starting_index + i), WrenchStamped,
@@ -111,13 +112,40 @@ class OptoforceDriver(object):
             wrench.header.frame_id = "optoforce_" + str(self._starting_index + i)
             self._wrenches.append(wrench)
 
+        # Advertise a service to retrieve the unique ID of the sensor
+        self._service = rospy.Service('get_unique_id', std_srvs.srv.Empty, self.get_unique_id)
+
+        # Tree representation of all accepted headers.
+        # Leaf nodes are the lenght of the frame associated with the header
+        self._headers = {
+            170:
+                {0:
+                    {18:
+                        {8: 14}},
+                7:
+                    {8:
+                        {10: 16,
+                        16: 34,
+                        28: 22}}}}
+        # self._headers = {
+        #     struct.pack('>B', 171):
+        #         {struct.pack('>B', 0):
+        #             {struct.pack('>B', 18):
+        #                 {struct.pack('>B', 8): 14}}},
+        #     struct.pack('>B', 170):
+        #         {struct.pack('>B', 7):
+        #             {struct.pack('>B', 8):
+        #                 {struct.pack('>B', 10): 16,
+        #                 struct.pack('>B', 16): 34,
+        #                 struct.pack('>B', 28): 22}}}}
+
     def config(self):
         speed = self._speed_values[rospy.get_param("~speed", "100Hz")]
         filter = self._filter_values[rospy.get_param("~filter", "15Hz")]
         zero = self._zeroing_values[rospy.get_param("~zero", "false")]
         config_length = 9
 
-        header = self._frame_header()
+        header = struct.pack('>4B', 170, 0, 50, 3)
         offset = 0
 
         frame = array.array('B', [0] * config_length)
@@ -130,16 +158,57 @@ class OptoforceDriver(object):
 
         self._serial.write(frame)
 
+    def get_unique_id(self, request):
+        config_length = 6
+        offset = 0
+
+        # Build the frame and send it
+        frame = array.array('B', [0] * config_length)
+        struct.pack_into('>6B', frame, offset, 171, 0, 18, 8, 0, 197)
+        self._serial.write(frame)
+
+        return std_srvs.srv.EmptyResponse()
+
     def run(self):
         """
         Runs the read loop.
         """
+        sizes_seen = []
+
         while not rospy.is_shutdown():
-            s = self._serial.read(self._sensor_frame_length[self._sensor_type])
-            rospy.logdebug(binascii.hexlify(s))
-            data = self._decode(s)
-            if data:
-                self._publish(data)
+            data = self._detect_header(self._headers)
+            if len(data) > 1 and len(data) not in sizes_seen:
+                sizes_seen.append(len(data))
+                format_string = '>' + str(len(data)) + 'B'
+                rospy.logdebug(format_string)
+                rospy.logdebug("frame s: " + str(struct.unpack(format_string, data)))
+
+            if len(data) > 1:
+                self._decode(data)
+            else:
+                rospy.logwarn("frame with unknown header received")
+
+            # s = self._serial.read(self._sensor_frame_length[self._sensor_type])
+            # rospy.logdebug(binascii.hexlify(s))
+            # data = self._decode(s)
+            # if data:
+            #     self._publish(data)
+
+    def _detect_header(self, tree):
+        raw_byte = self._serial.read()
+        byte = struct.unpack('>B', raw_byte)[0]
+
+        for header_byte, subtree in tree.items():
+            if byte == header_byte:
+                if type(subtree) is int:
+                    return raw_byte + self._serial.read(subtree-4)
+                else:
+                    next_bytes = self._detect_header(subtree)
+                    if next_bytes: # hacky
+                        return raw_byte + next_bytes
+                    else:
+                        return '' # hacky
+        return '' # hacky
 
     def _decode(self, frame):
         """
@@ -155,24 +224,33 @@ class OptoforceDriver(object):
             # of the loss of frame synchronisation
             # This method would be wrong if the cause were an actual transmission error, but this doesn't
             # seem to happen.
-            s = self._serial.read(self._config_response_frame_length)
+            # FIXME: s = self._serial.read(self._config_response_frame_length)
             return None
 
-        data = OptoforceData()
-        offset = 6
-        data.status = struct.unpack_from('>H', frame, offset)[0]
+        header = struct.unpack_from('>4B', frame)
 
-        for s in range(self._nb_sensors):
-            force_axes = []
-            for a in range(self._nb_axis):
-                offset += 2
-                val = struct.unpack_from('>h', frame, offset)[0]
-                # TODO Convert to Newtons (needs sensitivity report)
-                val = float(val) / self._scale[s][a]
-                force_axes.append(val)
-            data.force.append(force_axes)
+        data_headers = [(170, 7, 8, 10), (170, 7, 8, 16), (170, 7, 8, 28)]
+        if header in data_headers:
+            data = OptoforceData()
+            offset = 6
+            data.status = struct.unpack_from('>H', frame, offset)[0]
 
-        return data
+            for s in range(self._nb_sensors):
+                force_axes = []
+                for a in range(self._nb_axis):
+                    offset += 2
+                    val = struct.unpack_from('>h', frame, offset)[0]
+                    # TODO Convert to Newtons (needs sensitivity report)
+                    val = float(val) / self._scale[s][a]
+                    force_axes.append(val)
+                data.force.append(force_axes)
+
+            return data
+        elif header == (170, 0, 18, 8):
+            rospy.logdebug("header match for unique identifier!")
+            offset = 4
+            string = struct.unpack_from('>8c', frame, offset)
+            print(''.join(string))
 
     def _publish(self, data):
         stamp = rospy.Time.now()
@@ -207,13 +285,9 @@ class OptoforceDriver(object):
         checksum = struct.unpack_from('>H', frame, offset)[0]
         return calculated == checksum
 
-    @staticmethod
-    def _frame_header():
-        return struct.pack('>4B', 170, 0, 50, 3)
-
-
 if __name__ == '__main__':
-    rospy.init_node("optoforce")
+    rospy.init_node("optoforce", log_level=rospy.DEBUG)
     driver = OptoforceDriver()
     driver.config()
     driver.run()
+    # rospy.spin()

--- a/optoforce/src/optoforce/optoforce.py
+++ b/optoforce/src/optoforce/optoforce.py
@@ -256,7 +256,18 @@ class OptoforceDriver(object):
                 force_axes = []
                 for a in range(self._nb_axis):
                     offset += 2
-                    val = struct.unpack_from('>h', frame, offset)[0]
+                    try:
+                        val = struct.unpack_from('>h', frame, offset)[0]
+                    except struct.error as e:
+                        message = ("Problem unpacking frame "
+                                   + self._frame_to_string(frame)
+                                   + " at offset " + str(offset) + ".")
+                        rospy.logfatal(message +" Please "
+                                       + "check that you set the right numbers "
+                                       + "of channels and axes.")
+                        rospy.signal_shutdown(message)
+                        sys.exit(1)
+
                     # TODO Convert to Newtons (needs sensitivity report)
                     val = float(val) / self._scale[s][a]
                     force_axes.append(val)

--- a/optoforce/src/optoforce/optoforce.py
+++ b/optoforce/src/optoforce/optoforce.py
@@ -235,17 +235,13 @@ class OptoforceDriver(object):
     def _decode(self, frame):
         """
         Decodes a sensor frame
-        It assumes that we get an entire frame and nothing else from serial.read. This assumption simplifies the code
-        and it seems to be always true for the moment.
+        It assumes that we get an entire frame and nothing else from serial.read.
+
         @param frame - byte frame from the sensor
         """
         if not self._is_checksum_valid(frame):
-            rospy.logwarn("Bad checksum in frame:\n" + frame)
-            # This is a trick to recover the frame synchronisation without having to implement a state machine.
-            # We are assuming that the reception of a config response frame (of shorter length) is the cause
-            # of the loss of frame synchronisation
-            # This method would be wrong if the cause were an actual transmission error, but this doesn't
-            # seem to happen.
+            rospy.logwarn("Bad checksum in frame: "
+                          + self._frame_to_string(frame))
             return None
 
         header = struct.unpack_from('>4B', frame)

--- a/optoforce/src/optoforce/optoforce.py
+++ b/optoforce/src/optoforce/optoforce.py
@@ -218,7 +218,7 @@ class OptoforceDriver(object):
         @param frame - byte frame from the sensor
         """
         if not self._is_checksum_valid(frame):
-            rospy.logwarn("Bad checksum")
+            rospy.logwarn("Bad checksum in frame:\n" + frame)
             # This is a trick to recover the frame synchronisation without having to implement a state machine.
             # We are assuming that the reception of a config response frame (of shorter length) is the cause
             # of the loss of frame synchronisation
@@ -251,6 +251,9 @@ class OptoforceDriver(object):
             offset = 4
             string = struct.unpack_from('>8c', frame, offset)
             print(''.join(string))
+        else:
+            rospy.logwarn("I can't recognize the frame's header:\n" + frame)
+            return None
 
     def _publish(self, data):
         stamp = rospy.Time.now()

--- a/optoforce/src/optoforce/optoforce.py
+++ b/optoforce/src/optoforce/optoforce.py
@@ -151,7 +151,8 @@ class OptoforceDriver(object):
         checksum = self._checksum(frame, len(frame))
         offset = len(header) + 3
         struct.pack_into('>H', frame, offset, checksum)
-        rospy.logdebug(binascii.hexlify(frame))
+        rospy.logdebug("Sending configuration frame "
+                       + self._frame_to_string(frame))
 
         self._serial.write(frame)
 
@@ -175,7 +176,8 @@ class OptoforceDriver(object):
                 header = struct.unpack_from('>4B', frame)
                 response_arrived = (header == (170, 0, 18, 8))
             else:
-                rospy.loginfo("We got data that could not be decoded: " + frame)
+                rospy.logdebug("We got data that could not be decoded: "
+                              + self._frame_to_string(frame))
 
         # Parse the frame to retrieve the serial number
         if response_arrived:
@@ -195,7 +197,9 @@ class OptoforceDriver(object):
                 if isinstance(data, OptoforceData):
                     self._publish(data)
             else:
-                rospy.loginfo("We got data that could not be decoded: " + frame)
+                rospy.logdebug("We got data that could not be decoded: "
+                              + self._frame_to_string(frame))
+
 
     def _detect_header(self, tree):
         raw_byte = self._serial.read()
@@ -287,6 +291,10 @@ class OptoforceDriver(object):
 
         checksum = struct.unpack_from('>H', frame, offset)[0]
         return calculated == checksum
+
+    @staticmethod
+    def _frame_to_string(frame):
+        return str(struct.unpack('>'+str(len(frame))+'B', frame))
 
 if __name__ == '__main__':
     rospy.init_node("optoforce")

--- a/optoforce/src/optoforce/optoforce.py
+++ b/optoforce/src/optoforce/optoforce.py
@@ -164,6 +164,8 @@ class OptoforceDriver(object):
     def get_serial_number(self):
         """
         Ask the sensor for its serial number
+
+        @return the serial number as a string, or None if the request failed
         """
         config_length = 6
         offset = 0

--- a/optoforce/src/optoforce/optoforce.py
+++ b/optoforce/src/optoforce/optoforce.py
@@ -83,8 +83,8 @@ class OptoforceDriver(object):
         """
         Initialize OptoforceDriver object
         """
+        port = rospy.get_param("~port", "/dev/ttyACM0")
         try:
-            port = rospy.get_param("~port", "/dev/ttyACM0")
             self._serial = serial.Serial(port, 1000000, timeout=None)
         except serial.SerialException as e:
             rospy.logfatal(e.message)
@@ -128,6 +128,8 @@ class OptoforceDriver(object):
             serial_number = self.get_serial_number()
             if serial_number:
                 topic_basename += serial_number + '_'
+                rospy.loginfo("Sensor " + serial_number + " was found at port "
+                              + port)
             else:
                 rospy.logwarn("Cannot get the serial number from the sensor. "
                            "Falling back to the basinc name scheme")

--- a/optoforce/src/optoforce/optoforce.py
+++ b/optoforce/src/optoforce/optoforce.py
@@ -203,6 +203,15 @@ class OptoforceDriver(object):
 
 
     def _detect_header(self, tree):
+        """
+        Read from the serial port and give back the latest data frame.
+
+        To do so, we compare the data received with the next possible byte of
+        the headers descriped in tree. This method should be called with
+        self._headers. It will then recurse on subtrees of self._headers
+
+        @param tree - dictionary structure representing the next expected bytes
+        """
         try:
             raw_byte = self._serial.read()
             byte = struct.unpack('>B', raw_byte)[0]
@@ -302,6 +311,12 @@ class OptoforceDriver(object):
 
     @staticmethod
     def _frame_to_string(frame):
+        """
+        Build a string representing the given frame for pretty printing.
+
+        @param frame - array of bytes (or string) represnting a frame
+        @return human-readable string representation of the frame
+        """
         return str(struct.unpack('>'+str(len(frame))+'B', frame))
 
 if __name__ == '__main__':

--- a/optoforce/src/optoforce/optoforce.py
+++ b/optoforce/src/optoforce/optoforce.py
@@ -21,7 +21,6 @@ import serial
 import struct
 import binascii
 import rospy
-import std_srvs.srv
 from geometry_msgs.msg import WrenchStamped
 
 

--- a/optoforce/src/optoforce/optoforce.py
+++ b/optoforce/src/optoforce/optoforce.py
@@ -126,7 +126,11 @@ class OptoforceDriver(object):
         topic_basename = "optoforce_"
         if self._append_topic_serial:
             serial_number = self.get_serial_number()
-            topic_basename += serial_number + '_'
+            if serial_number:
+                topic_basename += serial_number + '_'
+            else:
+                rospy.logwarn("Cannot get the serial number from the sensor. "
+                           "Falling back to the basinc name scheme")
 
         for i in range(self._nb_sensors):
             self._publishers.append(rospy.Publisher(topic_basename +
@@ -181,8 +185,9 @@ class OptoforceDriver(object):
                               + self._frame_to_string(frame))
 
         # Parse the frame to retrieve the serial number
-        if response_arrived:
-            return ''.join(self._decode(frame)).strip()
+        serial_number = self._decode(frame)
+        if response_arrived and serial_number:
+            return ''.join(serial_number).strip()
         else:
             return None
 

--- a/optoforce/src/optoforce/optoforce.py
+++ b/optoforce/src/optoforce/optoforce.py
@@ -99,14 +99,18 @@ class OptoforceDriver(object):
         self._scale = rospy.get_param("~scale")
 
         if len(self._scale) != self._nb_sensors:
-            raise ValueError("Number of sensors [%i]and scaling factor vectors [%i] given doesn't match." % (self._nb_sensors, len(self._scale)))
+            raise ValueError("Number of sensors [%i]and scaling factor vectors "
+                "[%i] given doesn't match." % (self._nb_sensors, len(self._scale)))
         else:
             for x in range(self._nb_sensors):
                 if len(self._scale[x]) != self._nb_axis:
-                    raise ValueError("Number of axis [%i] and scaling factors [%i] given doesn't match." % (self._nb_axis, len(self._scale[x])))
+                    raise ValueError("Number of axis [%i] and scaling factors "
+                        "[%i] given doesn't match." % (self._nb_axis, len(self._scale[x])))
 
         for i in range(self._nb_sensors):
-            self._publishers.append(rospy.Publisher("optoforce_" + str(self._starting_index + i), WrenchStamped,
+            self._publishers.append(rospy.Publisher("optoforce_" +
+                                                    str(self._starting_index + i),
+                                                    WrenchStamped,
                                                     queue_size=100))
             wrench = WrenchStamped()
             wrench.header.frame_id = "optoforce_" + str(self._starting_index + i)
@@ -127,17 +131,6 @@ class OptoforceDriver(object):
                         {10: 16,
                         16: 34,
                         28: 22}}}}
-        # self._headers = {
-        #     struct.pack('>B', 171):
-        #         {struct.pack('>B', 0):
-        #             {struct.pack('>B', 18):
-        #                 {struct.pack('>B', 8): 14}}},
-        #     struct.pack('>B', 170):
-        #         {struct.pack('>B', 7):
-        #             {struct.pack('>B', 8):
-        #                 {struct.pack('>B', 10): 16,
-        #                 struct.pack('>B', 16): 34,
-        #                 struct.pack('>B', 28): 22}}}}
 
     def config(self):
         speed = self._speed_values[rospy.get_param("~speed", "100Hz")]
@@ -169,30 +162,45 @@ class OptoforceDriver(object):
 
         return std_srvs.srv.EmptyResponse()
 
+    def really_get_unique_id(self):
+        config_length = 6
+        offset = 0
+
+        # Build the request frame and send it
+        frame = array.array('B', [0] * config_length)
+        struct.pack_into('>6B', frame, offset, 171, 0, 18, 8, 0, 197)
+        self._serial.write(frame)
+
+        # Listen for response frames until the right one is found
+        response_arrived = False
+        while not rospy.is_shutdown() and not response_arrived:
+            frame_received, frame = self._detect_header(self._headers)
+            if frame_received:
+                header = struct.unpack_from('>4B', frame)
+                response_arrived = (header == (170, 0, 18, 8))
+            else:
+                rospy.logwarn("We got data that could not be decoded: " + frame)
+
+        # Parse the frame to retrieve the serial number
+        if response_arrived:
+            serial_number = self._decode(frame)
+            self._topic_suffix = serial_number
+        else:
+            self._topic_suffix = self._starting_index
+
     def run(self):
         """
         Runs the read loop.
         """
-        sizes_seen = []
-
         while not rospy.is_shutdown():
-            data = self._detect_header(self._headers)
-            if len(data) > 1 and len(data) not in sizes_seen:
-                sizes_seen.append(len(data))
-                format_string = '>' + str(len(data)) + 'B'
-                rospy.logdebug(format_string)
-                rospy.logdebug("frame s: " + str(struct.unpack(format_string, data)))
+            frame_received, frame = self._detect_header(self._headers)
 
-            if len(data) > 1:
-                self._decode(data)
+            if frame_received:
+                data = self._decode(frame)
+                if isinstance(data, OptoforceData):
+                    self._publish(data)
             else:
-                rospy.logwarn("frame with unknown header received")
-
-            # s = self._serial.read(self._sensor_frame_length[self._sensor_type])
-            # rospy.logdebug(binascii.hexlify(s))
-            # data = self._decode(s)
-            # if data:
-            #     self._publish(data)
+                rospy.logwarn("We got data that could not be decoded: " + frame)
 
     def _detect_header(self, tree):
         raw_byte = self._serial.read()
@@ -201,14 +209,12 @@ class OptoforceDriver(object):
         for header_byte, subtree in tree.items():
             if byte == header_byte:
                 if type(subtree) is int:
-                    return raw_byte + self._serial.read(subtree-4)
+                    return (True, raw_byte + self._serial.read(subtree-4))
                 else:
-                    next_bytes = self._detect_header(subtree)
-                    if next_bytes: # hacky
-                        return raw_byte + next_bytes
-                    else:
-                        return '' # hacky
-        return '' # hacky
+                    success, next_bytes = self._detect_header(subtree)
+                    return (success, raw_byte + next_bytes)
+
+        return (False, '')
 
     def _decode(self, frame):
         """
@@ -247,10 +253,11 @@ class OptoforceDriver(object):
 
             return data
         elif header == (170, 0, 18, 8):
-            rospy.logdebug("header match for unique identifier!")
             offset = 4
-            string = struct.unpack_from('>8c', frame, offset)
-            print(''.join(string))
+            serial_number = struct.unpack_from('>8c', frame, offset)
+            rospy.logdebug("We were given the following serial number: " +
+                            ''.join(serial_number))
+            return serial_number
         else:
             rospy.logwarn("I can't recognize the frame's header:\n" + frame)
             return None
@@ -292,5 +299,6 @@ if __name__ == '__main__':
     rospy.init_node("optoforce", log_level=rospy.DEBUG)
     driver = OptoforceDriver()
     driver.config()
+    driver.really_get_unique_id()
     driver.run()
     # rospy.spin()

--- a/optoforce/src/optoforce/optoforce.py
+++ b/optoforce/src/optoforce/optoforce.py
@@ -225,7 +225,6 @@ class OptoforceDriver(object):
             # of the loss of frame synchronisation
             # This method would be wrong if the cause were an actual transmission error, but this doesn't
             # seem to happen.
-            # FIXME: s = self._serial.read(self._config_response_frame_length)
             return None
 
         header = struct.unpack_from('>4B', frame)
@@ -290,7 +289,7 @@ class OptoforceDriver(object):
         return calculated == checksum
 
 if __name__ == '__main__':
-    rospy.init_node("optoforce", log_level=rospy.DEBUG)
+    rospy.init_node("optoforce")
     driver = OptoforceDriver()
     driver.config()
     driver.run()

--- a/optoforce/src/optoforce/optoforce.py
+++ b/optoforce/src/optoforce/optoforce.py
@@ -284,10 +284,12 @@ class OptoforceDriver(object):
         elif header == (170, 0, 18, 8):
             offset = 4
             serial_number = struct.unpack_from('>8c', frame, offset)
-            rospy.logdebug("We have the serial number " + ''.join(serial_number))
+            rospy.logdebug("We have the serial number "
+                           + ''.join(serial_number))
             return serial_number
         else:
-            rospy.logwarn("I can't recognize the frame's header:\n" + frame)
+            rospy.logwarn("I can't recognize the frame's header:\n"
+                          + self._frame_to_string(frame))
             return None
 
     def _publish(self, data):


### PR DESCRIPTION
Since we have six sensors on one robot, we need to have a way to uniquely identify them. Using the name that the OS gives them is not reliable enough since it depends on the order in which they are connected.

I propose to add the option for the topic name to contain the sensor's serial number.

A number of other changes were made, hopefully for the better.

Changes:
- Features:
  - add the parameter `~append_serial_number` to the node enabling the serial number based topic name (default to previous behaviour)
  - if enabled, set the topic name based on the sensor's serial number; the scheme is /optoforce_SERIAL_INDEX where SERIAL is the serial number and INDEX is as until now
  - properly detect frame headers (avoids occasional "bad checksum" warnings, used for serial number)
  - improved logging messages that now include a pretty printed representation of the frame
- Behind the scenes:
  - adding a few more comments
  - wrap long lines
  - remove `_frame_header` that was not generic and used only once
