### PR TITLE
Launch OPTOFORCE for H1 hand

### DIFF
--- a/optoforce/config/optoforce_h1_hand.rviz
+++ b/optoforce/config/optoforce_h1_hand.rviz
@@ -1,0 +1,284 @@
+Panels:
+  - Class: rviz/Displays
+    Help Height: 78
+    Name: Displays
+    Property Tree Widget:
+      Expanded:
+        - /Global Options1
+        - /Status1
+        - /RobotModel1/Links1
+        - /TF1/Frames1
+      Splitter Ratio: 0.771812
+    Tree Height: 435
+  - Class: rviz/Selection
+    Name: Selection
+  - Class: rviz/Tool Properties
+    Expanded:
+      - /2D Pose Estimate1
+      - /2D Nav Goal1
+      - /Publish Point1
+    Name: Tool Properties
+    Splitter Ratio: 0.588679
+  - Class: rviz/Views
+    Expanded:
+      - /Current View1
+    Name: Views
+    Splitter Ratio: 0.5
+  - Class: rviz/Time
+    Experimental: false
+    Name: Time
+    SyncMode: 0
+    SyncSource: ""
+Visualization Manager:
+  Class: ""
+  Displays:
+    - Alpha: 0.5
+      Cell Size: 1
+      Class: rviz/Grid
+      Color: 160; 160; 164
+      Enabled: true
+      Line Style:
+        Line Width: 0.03
+        Value: Lines
+      Name: Grid
+      Normal Cell Count: 0
+      Offset:
+        X: 0
+        Y: 0
+        Z: 0
+      Plane: XY
+      Plane Cell Count: 10
+      Reference Frame: <Fixed Frame>
+      Value: true
+    - Alpha: 1
+      Class: rviz/RobotModel
+      Collision Enabled: false
+      Enabled: true
+      Links:
+        All Links Enabled: true
+        Expand Joint Details: false
+        Expand Link Details: false
+        Expand Tree: false
+        H1_F1_base_link:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+        H1_F1_link_1:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+        H1_F1_link_2:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+        H1_F1_optoforce:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+        H1_F1_tip:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+        H1_F2_base_link:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+        H1_F2_link_1:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+        H1_F2_link_2:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+        H1_F2_optoforce:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+        H1_F2_tip:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+        H1_F3_base_link:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+        H1_F3_link_1:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+        H1_F3_link_2:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+        H1_F3_optoforce:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+        H1_F3_tip:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+        H1_base_attach:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+        H1_base_link:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+        H1_insert_F1:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+        H1_insert_F2:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+        H1_insert_F3:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+        H1_wrist_attach:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+        Link Tree Style: Links in Alphabetic Order
+      Name: RobotModel
+      Robot Description: robot_description
+      TF Prefix: ""
+      Update Interval: 0
+      Value: true
+      Visual Enabled: true
+    - Class: rviz/TF
+      Enabled: false
+      Frame Timeout: 15
+      Frames:
+        All Enabled: false
+      Marker Scale: 1
+      Name: TF
+      Show Arrows: true
+      Show Axes: true
+      Show Names: true
+      Tree:
+        {}
+      Update Interval: 0
+      Value: false
+    - Class: rviz/Axes
+      Enabled: false
+      Length: 0.3
+      Name: Axes
+      Radius: 0.01
+      Reference Frame: <Fixed Frame>
+      Value: false
+    - Alpha: 1
+      Arrow Width: 0.03
+      Class: rviz/WrenchStamped
+      Enabled: true
+      Force Arrow Scale: 0.5
+      Force Color: 204; 51; 51
+      History Length: 1
+      Name: Optoforce_0
+      Topic: /optoforce_0
+      Torque Arrow Scale: 0.5
+      Torque Color: 204; 204; 51
+      Unreliable: false
+      Value: true
+    - Alpha: 1
+      Arrow Width: 0.03
+      Class: rviz/WrenchStamped
+      Enabled: true
+      Force Arrow Scale: 0.5
+      Force Color: 204; 51; 51
+      History Length: 1
+      Name: Optoforce_1
+      Topic: /optoforce_1
+      Torque Arrow Scale: 0.5
+      Torque Color: 204; 204; 51
+      Unreliable: false
+      Value: true
+    - Alpha: 1
+      Arrow Width: 0.03
+      Class: rviz/WrenchStamped
+      Enabled: true
+      Force Arrow Scale: 0.5
+      Force Color: 204; 51; 51
+      History Length: 1
+      Name: Optoforce_2
+      Topic: /optoforce_2
+      Torque Arrow Scale: 0.5
+      Torque Color: 204; 204; 51
+      Unreliable: false
+      Value: true
+  Enabled: true
+  Global Options:
+    Background Color: 48; 48; 48
+    Fixed Frame: H1_base_link
+    Frame Rate: 100
+  Name: root
+  Tools:
+    - Class: rviz/Interact
+      Hide Inactive Objects: true
+    - Class: rviz/MoveCamera
+    - Class: rviz/Select
+    - Class: rviz/FocusCamera
+    - Class: rviz/Measure
+    - Class: rviz/SetInitialPose
+      Topic: /initialpose
+    - Class: rviz/SetGoal
+      Topic: /move_base_simple/goal
+    - Class: rviz/PublishPoint
+      Single click: true
+      Topic: /clicked_point
+  Value: true
+  Views:
+    Current:
+      Class: rviz/Orbit
+      Distance: 0.731916
+      Enable Stereo Rendering:
+        Stereo Eye Separation: 0.06
+        Stereo Focal Distance: 1
+        Swap Stereo Eyes: false
+        Value: false
+      Focal Point:
+        X: 0.0219344
+        Y: 0.052003
+        Z: 0.103558
+      Name: Current View
+      Near Clip Distance: 0.01
+      Pitch: 0.675398
+      Target Frame: <Fixed Frame>
+      Value: Orbit (rviz)
+      Yaw: 3.68358
+    Saved: ~
+Window Geometry:
+  Displays:
+    collapsed: false
+  Height: 716
+  Hide Left Dock: false
+  Hide Right Dock: false
+  QMainWindow State: 000000ff00000000fd00000004000000000000016a00000242fc0200000008fb0000001200530065006c0065006300740069006f006e00000001e10000009b0000006400fffffffb0000001e0054006f006f006c002000500072006f007000650072007400690065007302000001ed000001df00000185000000a3fb000000120056006900650077007300200054006f006f02000001df000002110000018500000122fb000000200054006f006f006c002000500072006f0070006500720074006900650073003203000002880000011d000002210000017afb000000100044006900730070006c006100790073010000002800000242000000dd00fffffffb0000002000730065006c0065006300740069006f006e00200062007500660066006500720200000138000000aa0000023a00000294fb00000014005700690064006500530074006500720065006f02000000e6000000d2000003ee0000030bfb0000000c004b0069006e0065006300740200000186000001060000030c00000261000000010000010f00000242fc0200000003fb0000001e0054006f006f006c002000500072006f00700065007200740069006500730100000041000000780000000000000000fb0000000a00560069006500770073010000002800000242000000b000fffffffb0000001200530065006c0065006300740069006f006e010000025a000000b200000000000000000000000200000490000000a9fc0100000001fb0000000a00560069006500770073030000004e00000080000002e10000019700000003000004b00000003efc0100000002fb0000000800540069006d00650100000000000004b0000002f600fffffffb0000000800540069006d006501000000000000045000000000000000000000022b0000024200000004000000040000000800000008fc0000000100000002000000010000000a0054006f006f006c00730100000000ffffffff0000000000000000
+  Selection:
+    collapsed: false
+  Time:
+    collapsed: false
+  Tool Properties:
+    collapsed: false
+  Views:
+    collapsed: false
+  Width: 1200
+  X: 136
+  Y: 14

--- a/optoforce/launch/optoforce_hand.launch
+++ b/optoforce/launch/optoforce_hand.launch
@@ -4,7 +4,9 @@
 
   <include file="$(find optoforce)/launch/optoforce.launch"/>
 
-  <include if="$(arg rviz)" file="$(find optoforce)/launch/rviz.launch"/>
+  <include if="$(arg rviz)" file="$(find optoforce)/launch/rviz.launch">
+    <arg name="h1_hand" value="$(arg h1)"/>
+  </include>
 
   <!-- Static transforms form Optoforce sensor to finger tip -->
   <group unless="$(arg h1)">

--- a/optoforce/launch/optoforce_hand.launch
+++ b/optoforce/launch/optoforce_hand.launch
@@ -1,13 +1,24 @@
 <launch>
   <arg name="rviz" default="true"/>
+  <arg name="h1" default="false"/>
 
   <include file="$(find optoforce)/launch/optoforce.launch"/>
 
   <include if="$(arg rviz)" file="$(find optoforce)/launch/rviz.launch"/>
 
   <!-- Static transforms form Optoforce sensor to finger tip -->
-  <node name="optoforce_0_broadcaster" pkg="tf" type="static_transform_publisher" args="0 0 0 0 0 1.57 rh_thtip optoforce_0 100" />
-  <node name="optoforce_1_broadcaster" pkg="tf" type="static_transform_publisher" args="0 0 0 0 0 1.57 rh_fftip optoforce_1 100" />
-  <node name="optoforce_2_broadcaster" pkg="tf" type="static_transform_publisher" args="0 0 0 0 0 1.57 rh_mftip optoforce_2 100" />
-  <node name="optoforce_3_broadcaster" pkg="tf" type="static_transform_publisher" args="0 0 0 0 0 1.57 rh_rftip optoforce_3 100" />
+  <group unless="$(arg h1)">
+    <node name="optoforce_0_broadcaster" pkg="tf" type="static_transform_publisher" args="0 0 0 0 0 1.57 rh_thtip optoforce_0 100" />
+    <node name="optoforce_1_broadcaster" pkg="tf" type="static_transform_publisher" args="0 0 0 0 0 1.57 rh_fftip optoforce_1 100" />
+    <node name="optoforce_2_broadcaster" pkg="tf" type="static_transform_publisher" args="0 0 0 0 0 1.57 rh_mftip optoforce_2 100" />
+    <node name="optoforce_3_broadcaster" pkg="tf" type="static_transform_publisher" args="0 0 0 0 0 1.57 rh_rftip optoforce_3 100" />
+  </group>
+
+  <!-- If you are using H1 hand publish different transformations -->
+  <group if="$(arg h1)">
+    <node name="optoforce_0_broadcaster" pkg="tf" type="static_transform_publisher" args="0 0 0 0 0 1.57 H1_F1_optoforce optoforce_0 100" />
+    <node name="optoforce_1_broadcaster" pkg="tf" type="static_transform_publisher" args="0 0 0 0 0 1.57 H1_F2_optoforce optoforce_1 100" />
+    <node name="optoforce_2_broadcaster" pkg="tf" type="static_transform_publisher" args="0 0 0 0 0 1.57 H1_F3_optoforce optoforce_2 100" />
+  </group>
+
 </launch>

--- a/optoforce/launch/rviz.launch
+++ b/optoforce/launch/rviz.launch
@@ -1,3 +1,12 @@
 <launch>
+
+  <arg name="h1_hand" default="false"/>
+  <!-- If we have h1 run different configuration than the default -->
+  <group if="$(arg h1_hand)">
+    <node name="rviz_optoforce" pkg="rviz" type="rviz" args="-d $(find optoforce)/config/optoforce_h1_hand.rviz" />
+  </group>
+
+  <group unless="$(arg h1_hand)">
     <node name="rviz_optoforce" pkg="rviz" type="rviz" args="-d $(find optoforce)/config/optoforce_hand.rviz" />
+  </group>
 </launch>


### PR DESCRIPTION
I introduced an argument for the `optoforce_hand.launch` which in case you set it, you launch OPTOFORCE for the H1 hand.

The changes are the following:
- Change the names of the last links of the hand in order to publish TF for the optoforce correctly.
- Change the rviz configuration in order to show the hand correctly.

I do not know if you would prefer a different launch file than the argument of the existing one.
